### PR TITLE
잘못된 useQuery를 useMutation으로 변경

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,6 @@ name: Run lighthouse CI When Push
 on:
   pull_request:
     branches-ignore:
-      - 'dev'
       - 'main'
 jobs:
   lhci:

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ['168.188.123.234', 'reduck.site', 'reduckas.site'],
+    domains: ['3.39.78.198', 'reduck.site', 'api.reduckas.site'],
   },
 };
 module.exports = nextConfig;

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "@stomp/stompjs": "^7.0.0",
     "@tailwindcss/nesting": "^0.0.0-insiders.565cd3e",
     "@tanstack/react-query": "^4.29.5",
+    "@tanstack/react-query-devtools": "^5.17.0",
     "@tiptap/extension-code-block-lowlight": "^2.1.12",
     "@tiptap/extension-highlight": "^2.1.12",
     "@tiptap/extension-image": "^2.1.12",

--- a/client/src/components/board/PostContent/index.tsx
+++ b/client/src/components/board/PostContent/index.tsx
@@ -20,7 +20,7 @@ interface IProps {
 function PostContent({ postOriginId }: IProps) {
   const user = useSelector((state: IReduxState) => state.auth);
 
-  const { data, refetch } = useQuery({
+  const { data } = useQuery({
     queryKey: [`${postOriginId}`],
     queryFn: async () => await postManager.getPost({ postOriginId }),
     retry: false,
@@ -37,23 +37,13 @@ function PostContent({ postOriginId }: IProps) {
       />
       <h3 className="pl-3 text-2xl font-bold">댓글 {comments?.length}</h3>
       <div className="flex flex-col border-gray-100 border-[1px] border-collapse">
-        <CommentUpload
-          user={user}
-          refetch={() => {
-            refetch();
-            setTimeout(
-              () => window.scrollTo(0, document.body.scrollHeight),
-              100
-            );
-          }}
-        />
+        <CommentUpload user={user} />
         {comments?.map((comment: IComment) => (
           <Comment
             key={comment.commentOriginId}
             data={comment}
             IS_AUTHOR={user.userId === comment.commentAuthorId}
             postOriginId={postOriginId}
-            refetch={refetch}
           />
         ))}
       </div>

--- a/client/src/components/board/PostContent/index.tsx
+++ b/client/src/components/board/PostContent/index.tsx
@@ -22,7 +22,7 @@ function PostContent({ postOriginId }: IProps) {
 
   const { data } = useQuery({
     queryKey: [`${postOriginId}`],
-    queryFn: async () => await postManager.getPost({ postOriginId }),
+    queryFn: () => postManager.getPost({ postOriginId }),
     retry: false,
     suspense: true,
   });

--- a/client/src/components/board/PostDetail/index.tsx
+++ b/client/src/components/board/PostDetail/index.tsx
@@ -63,7 +63,11 @@ export default function PostDetail({ data, IS_AUTHOR }: PostDetail) {
         {IS_AUTHOR && (
           <div className="flex gap-1 font-normal text-gray-500">
             <ModifyCotentButton postOriginId={data.postOriginId} />
-            <DeleteButton id={data.postOriginId} type="post" />
+            <DeleteButton
+              id={data.postOriginId}
+              type="post"
+              postOriginId={data.postOriginId}
+            />
           </div>
         )}
       </div>

--- a/client/src/components/board/PostDetail/index.tsx
+++ b/client/src/components/board/PostDetail/index.tsx
@@ -1,5 +1,5 @@
 //core
-import React from 'react';
+import React, { useEffect } from 'react';
 import Link from 'next/link';
 
 //interface
@@ -44,6 +44,12 @@ export default function PostDetail({ data, IS_AUTHOR }: PostDetail) {
     editable: false,
     content: data.postContent,
   });
+
+  useEffect(() => {
+    if (editor) {
+      editor.commands.setContent(data.postContent);
+    }
+  }, [data]);
 
   return (
     <article className="flex flex-col max-w-4xl min-w-full gap-8 px-4 py-6 m-auto bg-white border-2 border-gray-100 sm:p-12">

--- a/client/src/components/common/Post/Comment/index.stories.tsx
+++ b/client/src/components/common/Post/Comment/index.stories.tsx
@@ -49,10 +49,6 @@ const meta: Meta<typeof Comment> = {
     postOriginId: {
       description: '댓글이 속한 게시글의 고유 아이디입니다.',
     },
-    refetch: {
-      description:
-        '새로운 댓글 리스트를 불러오는 react-query 함수입니다. 댓글을 수정하거나 삭제한 후에 실행합니다.',
-    },
   },
 };
 

--- a/client/src/components/common/Post/Comment/index.tsx
+++ b/client/src/components/common/Post/Comment/index.tsx
@@ -16,13 +16,11 @@ interface ICommentProps {
   data: IComment;
   IS_AUTHOR: boolean;
   postOriginId: string;
-  refetch: () => void;
 }
 export default function Comment({
   data,
   IS_AUTHOR,
   postOriginId,
-  refetch,
 }: ICommentProps) {
   const [isModifying, setIsModifying] = useState(false);
   const [comment, setComment] = useState(data.commentContent);
@@ -66,11 +64,7 @@ export default function Comment({
                 취소
               </button>
             )}
-            <DeleteButton
-              id={data.commentOriginId}
-              type="comment"
-              refetch={refetch}
-            />
+            <DeleteButton id={data.commentOriginId} type="comment" />
           </div>
         )}
       </div>

--- a/client/src/components/common/Post/Comment/index.tsx
+++ b/client/src/components/common/Post/Comment/index.tsx
@@ -64,7 +64,11 @@ export default function Comment({
                 취소
               </button>
             )}
-            <DeleteButton id={data.commentOriginId} type="comment" />
+            <DeleteButton
+              id={data.commentOriginId}
+              type="comment"
+              postOriginId={postOriginId}
+            />
           </div>
         )}
       </div>

--- a/client/src/components/common/Post/CommentUpload/index.tsx
+++ b/client/src/components/common/Post/CommentUpload/index.tsx
@@ -1,5 +1,5 @@
 //core
-import React, { use } from 'react';
+import React from 'react';
 import { useRouter } from 'next/router';
 
 //components

--- a/client/src/components/common/Post/CommentUpload/index.tsx
+++ b/client/src/components/common/Post/CommentUpload/index.tsx
@@ -43,12 +43,13 @@ export default function CommentUpload({ user }: IComentUpload) {
   const comentImgSrc = user ? `${BASE_URL}${user.userProfileImgPath}` : '';
 
   const queryClient = useQueryClient();
-  const { mutate, isSuccess, isError } = useMutation({
+  const { mutate } = useMutation({
     mutationFn: (content: string) =>
       commentManager.createComment({ content, postOriginId }),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: [postOriginId] }),
   });
+
   const handleComment = async ({
     content,
     setSubmitting,
@@ -59,16 +60,12 @@ export default function CommentUpload({ user }: IComentUpload) {
       setSubmitting(false);
       return;
     }
-    mutate(content);
-
-    if (isSuccess) {
-      resetForm();
-      setSubmitting(false);
-    }
-    if (isError) {
-      setSubmitting(false);
-      openModal({ type: ModalType.ERROR, message: errorMessage.tryAgain });
-    }
+    mutate(content, {
+      onSuccess: resetForm,
+      onError: () =>
+        openModal({ type: ModalType.ERROR, message: errorMessage.tryAgain }),
+    });
+    setSubmitting(false);
   };
   return (
     <Formik

--- a/client/src/components/common/Post/CommentUpload/index.tsx
+++ b/client/src/components/common/Post/CommentUpload/index.tsx
@@ -61,7 +61,10 @@ export default function CommentUpload({ user }: IComentUpload) {
       return;
     }
     mutate(content, {
-      onSuccess: resetForm,
+      onSuccess: () => {
+        resetForm();
+        setTimeout(() => window.scrollTo(0, document.body.scrollHeight), 100);
+      },
       onError: () =>
         openModal({ type: ModalType.ERROR, message: errorMessage.tryAgain }),
     });

--- a/client/src/components/common/Post/DeleteButton/index.tsx
+++ b/client/src/components/common/Post/DeleteButton/index.tsx
@@ -12,42 +12,56 @@ import {
 //service
 import { postManager } from '@/service/post';
 import { commentManager } from '@/service/comment';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 interface IDeleteButton {
   id: string;
   type: 'comment' | 'post';
-  refetch?: () => void;
 }
 
-export default function DeleteButton({ id, type, refetch }: IDeleteButton) {
+export default function DeleteButton({ id, type }: IDeleteButton) {
   const { openModal } = useModal();
   const router = useRouter();
+  const queryClient = useQueryClient();
+  const postMutation = useMutation({
+    mutationFn: (id: string) => postManager.deletePost({ postOriginId: id }),
+    onSuccess: () => {
+      router.push('/');
+      openModal({
+        type: ModalType.SUCCESS,
+        message: successMessage.postDeleteSuccess,
+      });
+    },
+    onError: () =>
+      openModal({
+        type: ModalType.ERROR,
+        message: errorMessage.tryAgain,
+      }),
+  });
+  const commentMutation = useMutation({
+    mutationFn: (id: string) =>
+      commentManager.deleteComment({
+        commentOriginId: id,
+      }),
+    //TODO: id가 아닌 postOriginId를 넘겨줘야함
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: [id] }),
+    onError: () =>
+      openModal({
+        type: ModalType.ERROR,
+        message: errorMessage.tryAgain,
+      }),
+  });
+
   const IS_CHECK_MODAL_MESSAGE =
     type === 'post'
       ? warningMessage.confirmDeletePost
       : warningMessage.confirmDeleteComment;
 
   const handdleDelete = async () => {
-    try {
-      if (type === 'post') {
-        await postManager.deletePost({ postOriginId: id });
-
-        router.push('/');
-        openModal({
-          type: ModalType.SUCCESS,
-          message: successMessage.postDeleteSuccess,
-        });
-      } else if (type === 'comment') {
-        await commentManager.deleteComment({
-          commentOriginId: id,
-        });
-        refetch && refetch();
-      }
-    } catch (e) {
-      openModal({
-        type: ModalType.ERROR,
-        message: errorMessage.tryAgain,
-      });
+    if (type === 'post') {
+      postMutation.mutate(id);
+    } else if (type === 'comment') {
+      commentMutation.mutate(id);
     }
   };
   return (

--- a/client/src/components/common/Post/DeleteButton/index.tsx
+++ b/client/src/components/common/Post/DeleteButton/index.tsx
@@ -17,9 +17,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 interface IDeleteButton {
   id: string;
   type: 'comment' | 'post';
+  postOriginId: string;
 }
 
-export default function DeleteButton({ id, type }: IDeleteButton) {
+export default function DeleteButton({
+  id,
+  type,
+  postOriginId,
+}: IDeleteButton) {
   const { openModal } = useModal();
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -43,8 +48,8 @@ export default function DeleteButton({ id, type }: IDeleteButton) {
       commentManager.deleteComment({
         commentOriginId: id,
       }),
-    //TODO: id가 아닌 postOriginId를 넘겨줘야함
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: [id] }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: [postOriginId] }),
     onError: () =>
       openModal({
         type: ModalType.ERROR,

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -14,6 +14,8 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query';
 
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 function App({ Component, ...rest }: AppProps) {
   const { store, props } = wrapper.useWrappedStore(rest);
   const [queryClient] = useState(() => new QueryClient());
@@ -33,6 +35,7 @@ function App({ Component, ...rest }: AppProps) {
               <Component {...props} />
             </AuthComponent>
           </Hydrate>
+          <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
       </Provider>
     </>

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
@@ -18,7 +18,13 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 function App({ Component, ...rest }: AppProps) {
   const { store, props } = wrapper.useWrappedStore(rest);
-  const [queryClient] = useState(() => new QueryClient());
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
   return (
     <>
       <Head>

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2872,6 +2872,18 @@
   resolved "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.36.1.tgz"
   integrity sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==
 
+"@tanstack/query-devtools@5.15.0":
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.15.0.tgz#46fe98491be19cbbce8e2f4bb56190f94913ebec"
+  integrity sha512-oz+xBIf+fanmAQ3CZrV4t+1VZiK2nyTcH3zY3G8ukzw+LwX2QGa04ZfF+OCOVF6tPZ2dn1cekMibUb4tevf/aw==
+
+"@tanstack/react-query-devtools@^5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.17.0.tgz#32fd9aa23a10f37d5a04a43ea01a9f79075f4fba"
+  integrity sha512-G8sDsK83Zzjr6Nqm4t+8ILi9VWDhg/XjkDD4UYDWqDZHnh/iv4bbQotPLB3PfX7eQtdzgXjGaV8omf1UniyK8w==
+  dependencies:
+    "@tanstack/query-devtools" "5.15.0"
+
 "@tanstack/react-query@^4.29.5":
   version "4.36.1"
   resolved "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz"


### PR DESCRIPTION
## DONE

이전 회의때 게시글의 SEO 성능 향상을 위해 데이터를 서버단에서 받아오기 위해 개발을 진행하던 중 useQuery를 좀 더 깊게 공부해 보았고 [공식문서](https://tanstack.com/query/v4/docs/react/guides/mutations)에 따르면 useQuery는 get 요청시, 그 외에는 useMutation 훅을 사용한다고 함

그래서 기본에 Post요청인 경우 잘못된 useQuery를 useMutation을 통해 좀 더 로직이 깔끔해짐

하지만, 원래 목적이였던 게시글 정보를 getServersideProps를 통해 서버단에서 받아오려 했으나 문제가 발생

### 문제 상황
 Page router에는 [Steaming ssr](https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming)을 지원하지 않아 게시글 정보를 받아올떄까지 유저는 빈화면을 보여주어야함. 이로 인해 스켈레톤 UI 및 suspense를 사용할 수 없음

### 해결방안

이후 App router를 사용하면 Streaming ssr을 지원하기에 게시글 정보를 서버에서 받아오기 전 상태에 데이터와 관련되어 있지 않은 컴포넌트는 미리 클라이언트에 제공하여 빈화면을 제공하지 않음. 그리고 suspense까지 사용 가능하여 스켈레톤 UI를 적용하여 마치 csr처럼 작동한다는 장점이 있음. 차후 app router를 언제 이동할지 회의 후 진행 예정